### PR TITLE
Disable breakpoint placement at invalid locations

### DIFF
--- a/src/main/java/com/tang/intellij/lua/debugger/LuaLineBreakpointType.kt
+++ b/src/main/java/com/tang/intellij/lua/debugger/LuaLineBreakpointType.kt
@@ -21,6 +21,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiManager
 import com.intellij.psi.tree.TokenSet
+import com.intellij.util.text.CharArrayUtil.isEmptyOrSpaces
 import com.intellij.xdebugger.breakpoints.XLineBreakpointTypeBase
 import com.tang.intellij.lua.lang.LuaFileType
 import com.tang.intellij.lua.lang.LuaParserDefinition
@@ -40,9 +41,7 @@ class LuaLineBreakpointType : XLineBreakpointTypeBase(ID, NAME, LuaDebuggerEdito
 
         val lineStartOffset = doc.getLineStartOffset(line)
         val lineEndOffset = doc.getLineEndOffset(line)
-        val lineText = doc.text.substring(lineStartOffset, lineEndOffset).trim()
-
-        if (lineText.isEmpty()) return false
+        if (isEmptyOrSpaces(doc.charsSequence, lineStartOffset, lineEndOffset)) return false
 
         return generateSequence(psiFile.findElementAt(lineStartOffset)) { it.nextSibling }
             .takeWhile { it.textOffset < lineEndOffset }


### PR DESCRIPTION
While debugging, I find it particularly useful when the IDE prevents breakpoint placement in invalid locations, such as brackets, comments, blank lines, etc.

This PR attempts to address that initially. However, I'm not sure if you had other intentions when you first created it or if there's a better way to accomplish it. I'd love to hear more on that :)