### PR TITLE
Bugfix: Light files should have PSI only in one project

### DIFF
--- a/src/main/java/com/tang/intellij/lua/editor/LuaGutterCacheListener.kt
+++ b/src/main/java/com/tang/intellij/lua/editor/LuaGutterCacheListener.kt
@@ -64,7 +64,7 @@ class LuaDocumentListener(private val project: Project) : DocumentListener {
     override fun documentChanged(event: DocumentEvent) {
         val document = event.document
         val psiDocumentManager = PsiDocumentManager.getInstance(project)
-        val psiFile = psiDocumentManager.getPsiFile(document) as? LuaPsiFile ?: return
+        val psiFile = psiDocumentManager.getCachedPsiFile(document) as? LuaPsiFile ?: return
         val virtualFile = psiFile.virtualFile ?: return
 
         if (!virtualFile.isValid || virtualFile.fileType !== LuaFileType.INSTANCE) return


### PR DESCRIPTION
### Problem

When a given light file is already open, a subsequent edit in another project reuses that PSI, triggering IntelliJ’s guard that a light file may only belong to one project, and crashing at `FileManagerImpl.checkLightFileHasNoOtherPsi`:

```
java.lang.Throwable: Light files should have PSI only in one project, existing=com.intellij.psi.SingleRootFileViewProvider{vFile=LightVirtualFile: /, content=VirtualFileContent{size=28}, eventSystemEnabled=true} in Project(name=Intellij-Defold, containerState=COMPONENT_CREATED, componentStore=~/Projects/Intellij-Defold), requested in Project(name=vscode-defold, containerState=COMPONENT_CREATED, componentStore=~/Projects/vscode-defold); psiFiles: class com.tang.intellij.lua.psi.LuaPsiFile [Language: Lua]
	at com.intellij.openapi.diagnostic.Logger.error(Logger.java:375)
	at com.intellij.psi.impl.file.impl.FileManagerImpl.checkLightFileHasNoOtherPsi(FileManagerImpl.java:250)
	at com.intellij.psi.impl.file.impl.FileManagerImpl.findViewProvider(FileManagerImpl.java:230)
	at com.intellij.psi.impl.file.impl.FileManagerImpl.findFile(FileManagerImpl.java:525)
	at com.intellij.psi.impl.file.impl.FileManagerImpl.findFile(FileManagerImpl.java:511)
	at com.intellij.psi.impl.PsiManagerImpl.findFile(PsiManagerImpl.java:194)
	at com.tang.intellij.lua.editor.LuaDocumentListener.documentChanged$lambda$2$lambda$1(LuaGutterCacheListener.kt:95)
	...
```

This happens because `LuaDocumentListener` resolves the edited file by calling `FileDocumentManager` and then `PsiManager.findFile`, which can return a `LuaPsiFile` from either project that last created the shared `LightVirtualFile`. 

 ### Solution

The listener now gets the PSI through `PsiDocumentManager` for the current project/document pair, bails out when the document has no in-project Lua PSI or the backing file is invalid, and reuses that PSI/virtual file when clearing cache or restarting highlighting. 

This ties gutter invalidation and daemon restarts to the correct project-specific PSI instance, preventing shared light files from being requested across projects.
