### PR TITLE
fix: locate bundled binaries without hard-coded plugin dir

### DIFF
--- a/src/main/java/com/tang/intellij/lua/debugger/attach/EmmyAttachDebuggerProvider.kt
+++ b/src/main/java/com/tang/intellij/lua/debugger/attach/EmmyAttachDebuggerProvider.kt
@@ -35,7 +35,7 @@ class EmmyAttachDebuggerProvider : XAttachDebuggerProvider {
 
         // Build the process map once per "Attach to Process" dialog open.
         if (userDataHolder.getUserData(DETAIL_KEY) == null) {
-            if (archToolPath == null) {
+            if (resolveToolPath() == null) {
                 ApplicationManager.getApplication().invokeLater {
                     Notifications.Bus.notify(
                         Notification(

--- a/src/main/java/com/tang/intellij/lua/debugger/attach/ProcessUtils.kt
+++ b/src/main/java/com/tang/intellij/lua/debugger/attach/ProcessUtils.kt
@@ -2,10 +2,7 @@ package com.tang.intellij.lua.debugger.attach
 
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.util.ExecUtil
-import com.intellij.ide.plugins.PluginManagerCore
-import com.intellij.openapi.extensions.PluginId
 import com.tang.intellij.lua.psi.LuaFileUtil
-import java.io.File
 import java.nio.charset.Charset
 
 /**
@@ -16,10 +13,6 @@ import java.nio.charset.Charset
 fun resolveToolPath(): String? =
     LuaFileUtil.getPluginVirtualFile("debugger/emmy/windows/x86/emmy_tool.exe")
         ?: LuaFileUtil.getPluginVirtualFile("debugger/emmy/windows/x64/emmy_tool.exe")
-
-/** @deprecated Use [resolveToolPath] directly. Kept for call-site compatibility. */
-val archToolPath: String?
-    get() = resolveToolPath()
 
 fun listProcesses(): Map<Int, ProcessDetailInfo> {
     val toolPath = resolveToolPath() ?: return emptyMap()

--- a/src/main/java/com/tang/intellij/lua/psi/LuaFileUtil.kt
+++ b/src/main/java/com/tang/intellij/lua/psi/LuaFileUtil.kt
@@ -16,16 +16,9 @@
 
 package com.tang.intellij.lua.psi
 
-import com.intellij.ide.plugins.PluginDetailsService
-import com.intellij.ide.plugins.PluginManager
-import com.intellij.ide.plugins.PluginManagerCore
-import com.intellij.ide.plugins.cl.PluginAwareClassLoader
-import com.intellij.openapi.application.PathManager
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.psi.search.FilenameIndex
 import com.intellij.psi.search.ProjectAndLibrariesScope
 import com.intellij.util.PathUtil
@@ -41,13 +34,14 @@ import kotlin.io.path.pathString
  */
 object LuaFileUtil {
 
-    private val pluginId = PluginId.getId("com.cppcxy.Intellij-EmmyLua")
-
-    private val pluginPath: Path?
-        get() {
-            val pluginDir = PathManager.getPluginsDir()
-            return pluginDir.resolve("Intellij-EmmyLua2")
-        }
+    /**
+     * Root of this plugin's installation. The directory name is set by the build, so it must not
+     * be hard-coded; derive it from the jar this class ships in instead.
+     */
+    private val pluginPath: Path? by lazy {
+        val parent = Paths.get(PathUtil.getJarPathForClass(LuaFileUtil::class.java)).parent
+        if (parent?.fileName?.toString() == "lib") parent.parent else parent
+    }
 
     /**
      * Find a file by short URL with additional source roots for searching.
@@ -159,19 +153,13 @@ object LuaFileUtil {
         return VfsUtil.findRelativeFile(filename, project.baseDir)
     }
 
+    /**
+     * Absolute path of a bundled file, or `null` if absent. [path] is always relative to the
+     * plugin root: a leading separator would make [Path.resolve] escape the directory.
+     */
     fun getPluginVirtualFile(path: String): String? {
         val directory: Path = pluginPath ?: return null
-
-        val classesPath = directory.resolve("classes").resolve(path)
-        if (classesPath.exists()) {
-            return classesPath.pathString
-        }
-
-        val directPath = directory.resolve(path)
-        if (directPath.exists()) {
-            return directPath.pathString
-        }
-
-        return null
+        val target = directory.resolve(path.trimStart('/', '\\'))
+        return if (target.exists()) target.pathString else null
     }
 }

--- a/src/main/kotlin/com/cppcxy/ide/lsp/EmmyLuaAnalyzerAdaptor.kt
+++ b/src/main/kotlin/com/cppcxy/ide/lsp/EmmyLuaAnalyzerAdaptor.kt
@@ -26,7 +26,7 @@ object EmmyLuaAnalyzerAdaptor {
             if (EmmyLuaSettings.getInstance().location.isNotEmpty()) {
                 return EmmyLuaSettings.getInstance().location
             }
-            return LuaFileUtil.getPluginVirtualFile("/server/$exe").toString()
+            return LuaFileUtil.getPluginVirtualFile("server/$exe").orEmpty()
         }
 
     val canExecute: Boolean


### PR DESCRIPTION
Refs #54.

## Problem

`b471ce1` hard-coded the plugin directory as `Intellij-EmmyLua2`, but the build
names it after `intellijPlatform.projectName` — `IntelliJ-EmmyLua2`, capital `J`.
Works on Windows and macOS, breaks on any case-sensitive file system:
`emmylua_ls` and the Emmy debugger are never found on Linux.

That rewrite also looks unnecessary — `PathUtil.getJarPathForClass` is not
`@ApiStatus.Internal` in 2026.2. I checked every member of
`com.intellij.util.PathUtil` in `IU-262.8665.337`; only the `PluginManager`
descriptor accessors are, which is the actual constraint in #54.

Separately, `d45ab9e` began passing `"/server/$exe"` to `getPluginVirtualFile`,
and the leading separator makes `Path.resolve` escape the plugin directory
(`C:\server\…`). The language server is found on no OS at all unless its location
is set manually. Landed after 0.23.0.104, so no release is affected.

## Fix

Derive the root from the jar this class ships in, so no plugin name is involved,
and strip the leading separator once in `getPluginVirtualFile`. Drops the
`<pluginDir>/classes` probe (no shipped layout produces it), imports and a field
left dead by `b471ce1`, and the `archToolPath` alias.

## Verification

Against a locally installed `IU-262.8665.337`. Plugin Verifier 1.409 gives the
same verdict before and after — compatible, no internal API usage. `LuaFileUtil`
loaded through the platform's `UrlClassLoader` resolves the server, both debugger
tools and `emmyHelper.lua` from the unpacked distribution, and still does with the
plugin directory renamed.

Dead end worth recording: `Class.getProtectionDomain().getCodeSource()` has a null
location under `UrlClassLoader` — passes the Verifier, fails at runtime.
